### PR TITLE
Add API key to Gemini example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository contains a small example combining React and Phaser.js. The play
 
 Simply open `react-phaser-example/index.html` in a browser with internet access. The page loads React, ReactDOM, and Phaser from CDNs.
 
-The game will appear in the top of the page. Use the arrow keys to move the player toward the NPC sprite. When the two overlap, a dialog will appear.
+The game will appear in the top of the page. Use the arrow keys to move the player toward the NPC sprite. When the two overlap, the client calls the Gemini API and displays its response in a dialog. The included source already contains a Gemini API key for quick testing.
+
+Edit `react-phaser-example/index.js` to change the prompt text or replace the API key if needed.
 
 The code for the example resides in `react-phaser-example/index.js`.

--- a/react-phaser-example/index.js
+++ b/react-phaser-example/index.js
@@ -3,6 +3,34 @@
 
   function GameComponent() {
     const [showDialog, setShowDialog] = useState(false);
+    const [dialogText, setDialogText] = useState('');
+
+    const API_KEY = 'AIzaSyCpgL2OaqMCIfPQF0xxRyNZQ20pWiWQuQ4';
+
+    async function fetchGeminiResponse() {
+      setDialogText('Loading...');
+      setShowDialog(true);
+      try {
+        const response = await fetch(
+          `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${API_KEY}`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              contents: [
+                { parts: [{ text: 'Say hello to the player in a friendly way.' }] },
+              ],
+            }),
+          }
+        );
+        const data = await response.json();
+        const text =
+          data.candidates?.[0]?.content?.parts?.[0]?.text || 'No response';
+        setDialogText(text);
+      } catch (e) {
+        setDialogText('Error fetching response');
+      }
+    }
 
     useEffect(() => {
       class DemoScene extends Phaser.Scene {
@@ -19,9 +47,15 @@
 
           this.cursors = this.input.keyboard.createCursorKeys();
 
-          this.physics.add.overlap(this.player, this.npc, () => {
-            setShowDialog(true);
-          }, null, this);
+          this.physics.add.overlap(
+            this.player,
+            this.npc,
+            () => {
+              fetchGeminiResponse();
+            },
+            null,
+            this
+          );
         }
         update() {
           const speed = 150;
@@ -61,7 +95,7 @@
     return (
       React.createElement(React.Fragment, null,
         React.createElement('div', { id: 'gameContainer' }),
-        showDialog && React.createElement('div', { className: 'dialog' }, 'Hello NPC!')
+        showDialog && React.createElement('div', { className: 'dialog' }, dialogText)
       )
     );
   }


### PR DESCRIPTION
## Summary
- embed Gemini API key in index.js
- clarify README instructions about included API key

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_687cfde11994832f954cb1cc35d49941