### PR TITLE
Fix Gemini dialog on NPC collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository contains a small example combining React and Phaser.js. The play
 
 Simply open `react-phaser-example/index.html` in a browser with internet access. The page loads React, ReactDOM, and Phaser from CDNs.
 
-The game will appear in the top of the page. Use the arrow keys to move the player toward the NPC sprite. When the two overlap, a dialog will appear.
+The game will appear in the top of the page. Use the arrow keys to move the player toward the NPC sprite (a small chick). When the two overlap, the client calls the Gemini API and displays its response in a dialog. The included source already contains a Gemini API key for quick testing.
+
+Edit `react-phaser-example/index.js` to change the prompt text or replace the API key if needed.
 
 The code for the example resides in `react-phaser-example/index.js`.


### PR DESCRIPTION
## Summary
- only call Gemini API once by destroying overlap collider and tracking state
- update dialog logic so the Gemini response replaces the loading text
- return explicit errors from Gemini fetch and log them
- use a chick sprite for the NPC
- document the sprite change in the README

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_687cfde11994832f954cb1cc35d49941